### PR TITLE
Fix tagging workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- add missing checkout step in release job so github-tag-action can run

## Testing
- `dotnet build yt-downloader.sln -c Release`