### PR TITLE
Fix release workflow permissions for tag action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+# Grant write permissions so the workflow can create Git tags
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- grant write permissions to allow GitHub Actions workflow to create tags

## Testing
- `dotnet build yt-downloader.sln`