### PR TITLE
Make tool URLs configurable and tidy ffmpeg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,14 @@ jobs:
       - name: Publish application
         run: dotnet publish src/YoutubeDownloader/YoutubeDownloader.csproj -c Release -r win-x64 --self-contained false -o publish
 
-      - name: Archive binaries
-        run: Compress-Archive -Path publish/* -DestinationPath package.zip
+        - name: Archive binaries
+          run: Compress-Archive -Path publish/* -DestinationPath youtube-downloader.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        with:
-          name: yt-downloader
-          path: package.zip
+          with:
+            name: yt-downloader
+            path: youtube-downloader.zip
 
   release:
     runs-on: ubuntu-latest
@@ -56,9 +56,9 @@ jobs:
           DEFAULT_BUMP: patch
 
       - name: Create GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: package.zip
+          uses: ncipollo/release-action@v1
+          with:
+            artifacts: youtube-downloader.zip
           tag: ${{ steps.tag.outputs.new_tag }}
           token: ${{ secrets.GITHUB_TOKEN }}
           generate_release_notes: true

--- a/src/YoutubeDownloader/App.config
+++ b/src/YoutubeDownloader/App.config
@@ -10,6 +10,12 @@
             <setting name="SavePath" serializeAs="String">
                 <value />
             </setting>
+            <setting name="YtDlpUrl" serializeAs="String">
+                <value>https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe</value>
+            </setting>
+            <setting name="FfmpegUrl" serializeAs="String">
+                <value>https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip</value>
+            </setting>
         </YoutubeDownloader.Settings>
     </userSettings>
 </configuration>

--- a/src/YoutubeDownloader/MainWindow.xaml.cs
+++ b/src/YoutubeDownloader/MainWindow.xaml.cs
@@ -62,7 +62,7 @@ public partial class MainWindow : Window
             StatusText.Text = "Lade yt‑dlp …";
             try
             {
-                await DownloadFileAsync("https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe", ydPath);
+                await DownloadFileAsync(Settings.Default.YtDlpUrl, ydPath);
             }
             catch (Exception ex)
             {
@@ -75,8 +75,11 @@ public partial class MainWindow : Window
             StatusText.Text = "Lade ffmpeg …";
             try
             {
-                await DownloadFileAsync("https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip", new FileInfo(ffPath).DirectoryName, unzip: true);
-                File.Move("ffmpeg-master-latest-win64-gpl\\bin\\ffmpeg.exe", "tools\\ffmpeg.exe");
+                await DownloadFileAsync(Settings.Default.FfmpegUrl, new FileInfo(ffPath).DirectoryName!, unzip: true);
+                string tempDir = Path.Combine(_toolsDir, Path.GetFileNameWithoutExtension(new Uri(Settings.Default.FfmpegUrl).AbsolutePath));
+                File.Move(Path.Combine(tempDir, "bin", "ffmpeg.exe"), ffPath, overwrite: true);
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
             }
             catch (Exception ex)
             {

--- a/src/YoutubeDownloader/Properties/Settings.Designer.cs
+++ b/src/YoutubeDownloader/Properties/Settings.Designer.cs
@@ -34,5 +34,29 @@ namespace YoutubeDownloader.Properties {
                 this["SavePath"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe")]
+        public string YtDlpUrl {
+            get {
+                return ((string)(this["YtDlpUrl"]));
+            }
+            set {
+                this["YtDlpUrl"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip")]
+        public string FfmpegUrl {
+            get {
+                return ((string)(this["FfmpegUrl"]));
+            }
+            set {
+                this["FfmpegUrl"] = value;
+            }
+        }
     }
 }

--- a/src/YoutubeDownloader/Properties/Settings.settings
+++ b/src/YoutubeDownloader/Properties/Settings.settings
@@ -5,5 +5,11 @@
     <Setting Name="SavePath" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="YtDlpUrl" Type="System.String" Scope="User">
+      <Value Profile="(Default)">https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe</Value>
+    </Setting>
+    <Setting Name="FfmpegUrl" Type="System.String" Scope="User">
+      <Value Profile="(Default)">https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
## Summary
- configure `YtDlpUrl` and `FfmpegUrl` via app config
- delete temporary ffmpeg directory after extraction
- rename release artifact to `youtube-downloader.zip`

## Testing
- `dotnet build`